### PR TITLE
Fix name mismatch on 14 - Build Pipeline.md

### DIFF
--- a/content/14 - Build Pipeline.md
+++ b/content/14 - Build Pipeline.md
@@ -45,7 +45,7 @@ jobs:
       - name: Build application
         run: npm run build
       - name: Deploy to S3
-        run: aws s3 sync ./build/ s3://${{ secrets.BUCKET_ID }}
+        run: aws s3 sync ./build/ s3://${{ secrets.BUCKET_NAME }}
       - name: Create CloudFront invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
 ```


### PR DESCRIPTION
### Fix name mismatch

The current code sample on the readme documentation gives a different secret name `${{ secrets.BUCKET_ID }}` to the one used during the workshop `${{ secrets.BUCKET_NAME }}`

I referred to the readme when creating the secrets on GitHub and kept failing my tests, until I realized I used the wrong name 🙃 Hopefully this prevents others from having the same issue.